### PR TITLE
Add more applications and hide the .desktop for now

### DIFF
--- a/profiles/profile_database.json
+++ b/profiles/profile_database.json
@@ -188,6 +188,25 @@
     "data_dir": true
   },
   {
+    "names": [ "cemu" ],
+    "level": 2,
+    "filesystem": [
+      "xdg-download:ro",
+      "~/Games:ro",
+      "~/Roms:ro"
+    ],
+    "devices": [
+      "dri",
+      "input"
+    ],
+    "sockets": [
+      "x11",
+      "alsa",
+      "network"
+    ],
+    "data_dir": true
+  },
+  {
     "names": [ "chromium" ],
     "level": 2,
     "filesystem": [
@@ -250,6 +269,22 @@
   },
   {
     "names": [ "deemix-gui" ],
+    "level": 2,
+    "filesystem": [
+      "xdg-music:rw"
+    ],
+    "devices": [
+      "dri"
+    ],
+    "sockets": [
+      "x11",
+      "audio",
+      "network"
+    ],
+    "data_dir": true
+  },
+  {
+    "names": [ "deadbeef", "deadbeef nightly" ],
     "level": 2,
     "filesystem": [
       "xdg-music:rw"
@@ -1126,6 +1161,25 @@
     "data_dir": true
   },
   {
+    "names": [ "ryujinx" ],
+    "level": 2,
+    "filesystem": [
+      "xdg-download:ro",
+      "~/Games:ro",
+      "~/Roms:ro"
+    ],
+    "devices": [
+      "dri",
+      "input"
+    ],
+    "sockets": [
+      "x11",
+      "alsa",
+      "network"
+    ],
+    "data_dir": true
+  },
+  {
     "names": [ "sengi" ],
     "level": 1,
     "filesystem": null,
@@ -1488,7 +1542,7 @@
     "data_dir": true
   },
   {
-    "names": [ "yuzu" ],
+    "names": [ "yuzu", "suyu", "sudachi" ],
     "level": 2,
     "filesystem": [
       "xdg-download:ro",

--- a/resources/aisap.desktop
+++ b/resources/aisap.desktop
@@ -6,6 +6,7 @@ Comment=(EXPERIMENTAL) Sandbox helper for AppImages
 Exec=aisap
 Icon=io.github.mgord9518.aisap
 Terminal=true
+NoDisplay=true
 Categories=System;Security;
 X-AppImage-Version=
 X-AppImage-Architecture=


### PR DESCRIPTION
Hi, after some trouble we finally added aisap to AM and application installed by AM can easily be sandbox by running `am --sandbox appname` and I've been testing it with several apps. 

The results have been amazing, but there are some applications that don't get their fake home dir created, I have a feeling that is because they are not in the internal list. 

I just added them to test that theory. I tried to use the CI in the repo but I had a mismatched hash error? so now I'm here 😅

Also added the `NoDisplay=true` to the .desktop of aisap for now.