### PR TITLE
Add vulkan to level 2 and fix typo

### DIFF
--- a/wrap.go
+++ b/wrap.go
@@ -169,7 +169,7 @@ func (ai *AppImage) mainWrapArgs() []string {
 			"--ro-bind-try", ai.resolve("usr/share/themes"),       "/usr/share/themes",
 			"--ro-bind-try", ai.resolve("usr/share/applications"), "/usr/share/applications",
 			"--ro-bind-try", ai.resolve("usr/share/mime"),         "/usr/share/mime",
-			"--ro-bind-try", ai.resolve("usr/share/libdrm"),       "/usr/share/librdm",
+			"--ro-bind-try", ai.resolve("usr/share/libdrm"),       "/usr/share/libdrm",
 			"--ro-bind-try", ai.resolve("usr/share/vulkan"),       "/usr/share/vulkan",
 			"--ro-bind-try", ai.resolve("usr/share/glvnd"),        "/usr/share/glvnd",
 			"--ro-bind-try", ai.resolve("usr/share/glib-2.0"),     "/usr/share/glib-2.0",

--- a/wrap.go
+++ b/wrap.go
@@ -170,6 +170,7 @@ func (ai *AppImage) mainWrapArgs() []string {
 			"--ro-bind-try", ai.resolve("usr/share/applications"), "/usr/share/applications",
 			"--ro-bind-try", ai.resolve("usr/share/mime"),         "/usr/share/mime",
 			"--ro-bind-try", ai.resolve("usr/share/libdrm"),       "/usr/share/librdm",
+			"--ro-bind-try", ai.resolve("usr/share/vulkan"),       "/usr/share/vulkan",
 			"--ro-bind-try", ai.resolve("usr/share/glvnd"),        "/usr/share/glvnd",
 			"--ro-bind-try", ai.resolve("usr/share/glib-2.0"),     "/usr/share/glib-2.0",
 			"--ro-bind-try", ai.resolve("usr/share/terminfo"),     "/usr/share/terminfo",


### PR DESCRIPTION
Emulators need this location to start vulkan. 

Test showing the before and after:

![image](https://github.com/mgord9518/aisap/assets/36420837/855a3fb1-576b-48f8-bd77-9763ce5a6516)

------------------------------------------------------------------------------------

As I was writing this PR I noticed that I still had the missing libdrm error, that's odd. Turns out there was a typo `librdm` instead of `libdrm` and that is why libdrm was failing. 

After fixing the typo the error is gone: 

![image](https://github.com/mgord9518/aisap/assets/36420837/905ce093-a69d-42ac-b977-f26d2630e7be)

------------------------------------------------------------------------------------

Now I just need to find out why I get that `file: could not find any valid magic files!` error, it goes away if I give full access to `/usr/share` and I haven't been able to figure out which directory is needed. 

**EDIT**: Alright what's causing the last error is that suyu needs access to `/usr/share/file`, however I'm not sure if this is a spooky location (tbh I'm not sure that this location is for lol). let me know if you want me to add it to level 2, so far it seems to be harmless when suyu doesn't have that location given. 