### PR TITLE
Add Zen Browser

### DIFF
--- a/profiles/profile_database.json
+++ b/profiles/profile_database.json
@@ -1620,5 +1620,22 @@
       "network"
     ],
     "data_dir": true
+  },
+  {
+    "names": [ "zen browser" ],
+    "level": 2,
+    "filesystem": [
+      "xdg-download:rw"
+    ],
+    "devices": [
+      "dri"
+    ],
+    "sockets": [
+      "x11",
+      "pulseaudio",
+      "network",
+      "dbus"
+    ],
+    "data_dir": true
   }
 ]


### PR DESCRIPTION
New [firefox fork](https://github.com/zen-browser/desktop) that recently became widely popular.

You mentioned something about moving all browsers to level 1, I didn't do it here and copied the perms from librewolf since I'm not sure if devices have to be specified from level 1 is used since doesn't level 1 already give access to all devices?